### PR TITLE
Strip ANSI Escape sequences before attempting to parse YAML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "parse_datetime",
  "serde",
  "serde_yaml",
+ "strip-ansi-escapes",
  "tokio",
  "tokio-stream",
 ]
@@ -543,6 +544,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +624,26 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ inline_colorization = "0.1.6"
 parse_datetime = "0.6.0"
 serde = { version = "1.0.214", features = ["derive"] }
 serde_yaml = "0.9.34"
+strip-ansi-escapes = "0.2.0"
 tokio = { version = "1.41.0", features = [
     "rt-multi-thread",
     "io-util",

--- a/src/log.rs
+++ b/src/log.rs
@@ -12,7 +12,16 @@ pub struct Log<Format> {
 
 impl<Format> Log<Format> {
     pub fn parse(yaml: &str) -> Option<Self> {
-        serde_yaml::from_str(yaml).ok()?
+        let cleaned = strip_ansi_escapes::strip_str(yaml);
+
+        match serde_yaml::from_str(&cleaned) {
+            Ok(log) => Some(log),
+            Err(e) => {
+                eprintln!("Failed to parse YAML: {}", e);
+                eprintln!("YAML content:\n{}", cleaned);
+                None
+            }
+        }
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -19,8 +19,13 @@ where
         if line == "---" {
             // Parse the collected YAML block if it's non-empty
             if !yaml_buffer.trim().is_empty() {
-                if let Some(entry) = Log::<F>::parse(&yaml_buffer) {
-                    write!(writer, "{entry}")?;
+                match Log::<F>::parse(&yaml_buffer) {
+                    Some(entry) => {
+                        write!(writer, "{entry}")?;
+                    }
+                    None => {
+                        eprintln!("Failed to parse log entry:\n{}", yaml_buffer);
+                    }
                 }
                 yaml_buffer.clear();
             }


### PR DESCRIPTION
Logs with embedded ANSI escape sequences are being dropped and YAML parsing was silent on errors. This introduces error reporting and strips the escape sequences before attempting to parse.